### PR TITLE
Restyle portfolio section to match reference block

### DIFF
--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -1,61 +1,100 @@
 import yanaPortrait from '@/assets/yana-portrait.jpg';
 
 const AboutSection = () => {
+  const infoHighlights = [
+    (
+      <>
+        <span className="font-semibold text-[#FF62B1]">Я УЖЕ 15 ЛЕТ</span>{' '}
+        Я ДЕЛАЮ РУКИ И НОЖКИ МОИХ КЛИЕНТОВ НЕ ПРОСТО УХОЖЕННЫМИ, А{' '}
+        <span className="font-semibold text-[#FF62B1]">БЕЗУПРЕЧНЫМИ.</span>
+      </>
+    ),
+    (
+      <>
+        <span className="font-semibold text-[#FF62B1]">
+          ЖИВУ И РАБОТАЮ В РОСТОВЕ-НА-ДОНУ.
+        </span>
+      </>
+    ),
+    (
+      <>
+        ГЛУБОКАЯ ЭКСПЕРТИЗА ПОЗВОЛЯЕТ МНЕ НЕ ТОЛЬКО{' '}
+        <span className="font-semibold text-[#FF62B1]">ДЕЛАТЬ СЛОЖНЕЙШИЕ РАБОТЫ,</span>{' '}
+        НО И УЧИТЬ ЭТОМУ ДРУГИХ — Я С РАДОСТЬЮ ДЕЛЮСЬ СВОИМИ ЗНАНИЯМИ НА КУРСАХ И СМОГУ{' '}
+        <span className="font-semibold text-[#FF62B1]">ВАС НАУЧИТЬ ЭТОМУ С 0.</span>
+      </>
+    ),
+    (
+      <>
+        ОБОЖАЮ ВЫЗОВЫ И <span className="font-semibold text-[#FF62B1]">ТРУДНЫЕ ЗАДАЧИ!</span>{' '}
+        ЕСЛИ У ВАС ЕСТЬ <span className="font-semibold text-[#FF62B1]">ПРОБЛЕМА С НОГТЯМИ,</span>{' '}
+        КОТОРУЮ НИКТО НЕ МОЖЕТ РЕШИТЬ, — ВАМ КО МНЕ. ВМЕСТЕ НАЙДЁМ{' '}
+        <span className="font-semibold text-[#FF62B1]">РЕШЕНИЕ И СДЕЛАЕМ ВАМ НОВЫЙ ОБРАЗ ЗА 1.5 ЧАСА</span>
+      </>
+    ),
+  ];
+
   return (
-    <section id="about" className="py-20 bg-background">
-      <div className="container mx-auto px-4">
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-16 items-center">
-          {/* Left side - Decorative circles and photo */}
-          <div className="flex justify-center lg:justify-start">
-            <div className="relative">
-              {/* Decorative circles */}
-              <div className="absolute -left-20 -top-10 w-32 h-32 bg-primary/20 rounded-full"></div>
-              <div className="absolute -left-10 top-20 w-24 h-24 bg-secondary/30 rounded-full"></div>
-              <div className="absolute left-10 -top-5 w-20 h-20 bg-primary/15 rounded-full"></div>
-              
-              {/* Main photo circle */}
-              <div className="relative w-80 h-80 rounded-full overflow-hidden border-4 border-primary/30 shadow-2xl">
-                <img 
-                  src={yanaPortrait} 
-                  alt="Яна Пилит - мастер маникюра" 
-                  className="w-full h-full object-cover"
+    <section id="about" className="relative bg-background py-24">
+      <div className="absolute inset-x-0 top-0 hidden h-64 bg-gradient-to-b from-[rgba(255,98,177,0.12)] to-transparent lg:block" />
+      <div className="container relative mx-auto px-4">
+        <div className="grid items-center gap-16 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,1fr)]">
+          <div className="order-2 flex justify-center lg:order-1 lg:justify-start">
+            <div className="relative flex h-[22rem] w-[22rem] items-center justify-center sm:h-[26rem] sm:w-[26rem] lg:h-[30rem] lg:w-[30rem]">
+              <div
+                className="absolute -inset-[28%] rounded-full bg-[radial-gradient(circle,_rgba(255,98,177,0.26)_0%,_rgba(9,2,14,0)_70%)]"
+                aria-hidden="true"
+              />
+              <div
+                className="absolute -inset-[18%] rounded-full border border-[rgba(255,98,177,0.35)]"
+                aria-hidden="true"
+              />
+              <div
+                className="absolute -inset-[10%] rounded-full border border-[rgba(255,98,177,0.22)]"
+                aria-hidden="true"
+              />
+              <div
+                className="absolute inset-0 rounded-full bg-[radial-gradient(circle_at_top_left,_rgba(255,98,177,0.3),_rgba(11,4,15,0)_68%)]"
+                aria-hidden="true"
+              />
+
+              <div className="relative h-full w-full overflow-hidden rounded-full border-[6px] border-[#FF62B1] bg-[#0b050d] shadow-[0_45px_95px_-40px_rgba(255,98,177,0.85)]">
+                <img
+                  src={yanaPortrait}
+                  alt="Яна Пилит - мастер маникюра"
+                  className="h-full w-full object-cover"
                 />
-                <div className="absolute inset-0 bg-gradient-to-br from-primary/20 to-transparent"></div>
-              </div>
-              
-              {/* Decorative text around circle */}
-              <div className="absolute inset-0 flex items-center justify-center">
-                <div className="w-96 h-96 rounded-full border border-primary/20 flex items-center justify-center">
-                  <div className="text-primary/60 text-sm font-medium tracking-widest transform -rotate-12">
-                    Я Н А &nbsp; П И Л И Т &nbsp; / &nbsp; Я Н А &nbsp; П И Л И Т
-                  </div>
-                </div>
+                <div className="absolute inset-0 bg-gradient-to-br from-transparent via-transparent to-[rgba(9,0,12,0.45)]" aria-hidden="true" />
               </div>
             </div>
           </div>
 
-          {/* Right side - Text content */}
-          <div className="space-y-8">
-            <h2 className="font-heading text-4xl lg:text-6xl font-bold gradient-text mb-8">
-              МЕНЯ ЗОВУТ ЯНА
-            </h2>
-            
-            <div className="border-2 border-primary p-8 rounded-2xl space-y-6 text-lg leading-relaxed">
-              <p className="text-foreground">
-                <span className="text-primary font-semibold">Я УЖЕ 15 ЛЕТ</span> Я ДЕЛАЮ РУКИ И НОЖКИ МОИХ КЛИЕНТОВ НЕ ПРОСТО УХОЖЕННЫМИ, А <span className="text-primary font-semibold">БЕЗУПРЕЧНЫМИ.</span>
-              </p>
-              
-              <p className="text-foreground">
-                <span className="text-primary font-semibold">ЖИВУ И РАБОТАЮ В РОСТОВЕ-НА-ДОНУ.</span>
-              </p>
-              
-              <p className="text-foreground">
-                ГЛУБОКАЯ ЭКСПЕРТИЗА ПОЗВОЛЯЕТ МНЕ НЕ ТОЛЬКО <span className="text-primary font-semibold">ДЕЛАТЬ СЛОЖНЕЙШИЕ РАБОТЫ,</span> НО И УЧИТЬ ЭТОМУ ДРУГИХ — Я С РАДОСТЬЮ ДЕЛЮСЬ СВОИМИ ЗНАНИЯМИ НА КУРСАХ И СМОГУ <span className="text-primary font-semibold">ВАС НАУЧИТЬ ЭТОМУ С 0.</span>
-              </p>
-              
-              <p className="text-foreground">
-                ОБОЖАЮ ВЫЗОВЫ И <span className="text-primary font-semibold">ТРУДНЫЕ ЗАДАЧИ!</span> ЕСЛИ У ВАС ЕСТЬ <span className="text-primary font-semibold">ПРОБЛЕМА С НОГТЯМИ,</span> КОТОРУЮ НИКТО НЕ МОЖЕТ РЕШИТЬ, — ВАМ КО МНЕ. ВМЕСТЕ НАЙДЁМ <span className="text-primary font-semibold">РЕШЕНИЕ И СДЕЛАЕМ ВАМ НОВЫЙ ОБРАЗ ЗА 1.5 ЧАСА</span>
-              </p>
+          <div className="order-1 space-y-10 text-left lg:order-2">
+            <div className="space-y-4">
+              <p className="text-sm uppercase tracking-[0.48em] text-[rgba(255,98,177,0.7)]">Мастер ногтевого сервиса</p>
+              <h2 className="font-heading text-4xl font-bold uppercase text-foreground sm:text-5xl lg:text-6xl">
+                МЕНЯ ЗОВУТ <span className="text-[#FF62B1]">ЯНА</span>
+              </h2>
+            </div>
+
+            <div className="flex justify-center lg:justify-start">
+              <div className="relative w-full max-w-[34rem]">
+                <div
+                  className="pointer-events-none absolute -inset-6 hidden rounded-[3rem] border border-[rgba(255,98,177,0.32)] sm:block"
+                  aria-hidden="true"
+                />
+                <div
+                  className="pointer-events-none absolute -inset-12 hidden rounded-[3rem] border border-[rgba(255,98,177,0.18)] lg:block"
+                  aria-hidden="true"
+                />
+                <div className="relative overflow-hidden rounded-[3rem] border-[3px] border-[rgba(255,98,177,0.68)] bg-[rgba(12,3,16,0.78)] px-8 py-10 text-lg leading-relaxed text-foreground shadow-[0_35px_90px_-45px_rgba(255,98,177,0.75)] backdrop-blur-sm sm:px-12 sm:py-14">
+                  <div className="space-y-6">
+                    {infoHighlights.map((content, index) => (
+                      <p key={index}>{content}</p>
+                    ))}
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -10,58 +10,68 @@ const HeroSection = () => {
   };
 
   return (
-    <section className="min-h-screen flex items-center justify-center relative overflow-hidden bg-background">
-      <div className="container mx-auto px-4 grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
-        {/* Left side - Text content */}
-        <div className="text-left space-y-8 animate-slide-up">
-          <h1 className="font-heading text-5xl lg:text-7xl font-bold leading-tight">
-            <span className="gradient-text">КРАСИВЫЕ НОГТИ —</span>
-            <br />
-            <span className="gradient-text">ЭТО ПРОСТО</span>
-          </h1>
-          
-          <div className="space-y-4 text-lg lg:text-xl">
-            <p className="text-foreground">
-              ЕСЛИ ВЫ ИСКАЛИ <span className="text-primary font-semibold">ЛУЧШЕГО МАСТЕРА</span>
-            </p>
-            <p className="text-foreground">
-              ПО УХОДУ ЗА СВОИМИ НОГТЯМИ В
-            </p>
-            <p className="text-foreground">
-              ГОРОДЕ
-            </p>
-            <p className="text-primary text-3xl font-bold font-heading">
-              РОСТОВ - НА - ДОНУ
-            </p>
-            <p className="text-foreground">
-              ТО ВЫ ЕГО НАШЛИ
-            </p>
-          </div>
+    <section className="relative isolate flex min-h-screen items-center overflow-hidden bg-[#050505]">
+      <div className="absolute inset-0">
+        <div className="absolute inset-0 bg-[#050505]" aria-hidden="true" />
+        <img
+          src={pantherHero}
+          alt=""
+          aria-hidden="true"
+          className="pointer-events-none absolute right-[-12%] top-1/2 hidden h-[125%] max-w-none -translate-y-1/2 object-contain md:block"
+        />
+        <img
+          src={pantherHero}
+          alt=""
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 block h-full w-full object-cover object-right opacity-30 md:hidden"
+        />
+        <div
+          className="absolute inset-0 bg-gradient-to-r from-[#050505] via-[#050505]/95 to-transparent"
+          aria-hidden="true"
+        />
+      </div>
 
-          <Button 
-            onClick={scrollToContact}
-            className="btn-hero text-xl px-12 py-6 mt-8"
-          >
-            ЗАПИСАТЬСЯ
-          </Button>
-        </div>
-
-        {/* Right side - Panther image */}
-        <div className="flex justify-center lg:justify-end animate-float">
-          <div className="relative">
-            <img 
-              src={pantherHero} 
-              alt="Элегантная пантера - символ красоты и изящества" 
-              className="w-full max-w-lg h-auto object-cover rounded-3xl shadow-2xl"
-            />
-            <div className="absolute inset-0 bg-gradient-to-br from-primary/20 to-transparent rounded-3xl"></div>
+      <div className="container relative z-10 mx-auto px-4 py-20 lg:py-32">
+        <div className="max-w-xl rounded-[40px] border border-primary/20 bg-background/80 p-8 sm:p-12 shadow-2xl backdrop-blur-md text-left animate-slide-up">
+          <div className="space-y-6">
+            <p className="text-sm font-semibold uppercase tracking-[0.55em] text-muted-foreground">
+              ЯНА ПИЛИТ
+            </p>
+            <h1 className="font-heading text-4xl sm:text-5xl lg:text-6xl font-bold leading-tight uppercase">
+              <span className="gradient-text">КРАСИВЫЕ НОГТИ —</span>
+              <br />
+              <span className="gradient-text">ЭТО ПРОСТО</span>
+            </h1>
+            <div className="space-y-2 text-lg sm:text-xl font-medium text-foreground">
+              <p>
+                ЕСЛИ ВЫ ИСКАЛИ{' '}
+                <span className="text-primary font-semibold">ЛУЧШЕГО МАСТЕРА</span>
+              </p>
+              <p>ПО УХОДУ ЗА СВОИМИ НОГТЯМИ В</p>
+              <p>ГОРОДЕ</p>
+              <p className="text-primary text-3xl font-bold font-heading tracking-wide">
+                РОСТОВ - НА - ДОНУ
+              </p>
+              <p>ТО ВЫ ЕГО НАШЛИ</p>
+            </div>
+            <Button
+              onClick={scrollToContact}
+              className="btn-hero text-lg sm:text-xl px-10 sm:px-12 py-5 sm:py-6 mt-4"
+            >
+              ЗАПИСАТЬСЯ
+            </Button>
           </div>
         </div>
       </div>
 
-      {/* Decorative background elements */}
-      <div className="absolute top-20 left-10 w-20 h-20 bg-primary/10 rounded-full blur-xl animate-pulse"></div>
-      <div className="absolute bottom-20 right-10 w-32 h-32 bg-secondary/10 rounded-full blur-xl animate-pulse delay-1000"></div>
+      <div
+        className="absolute -left-24 top-24 hidden h-64 w-64 rounded-full bg-primary/20 blur-3xl md:block"
+        aria-hidden="true"
+      />
+      <div
+        className="absolute bottom-10 left-1/3 h-40 w-40 rounded-full bg-secondary/30 blur-3xl"
+        aria-hidden="true"
+      />
     </section>
   );
 };

--- a/src/components/PortfolioSection.tsx
+++ b/src/components/PortfolioSection.tsx
@@ -1,112 +1,155 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-import { Button } from '@/components/ui/button';
+
 import nails1 from '@/assets/nails-1.jpg';
 import nails2 from '@/assets/nails-2.jpg';
+import { Button } from '@/components/ui/button';
+
+type PortfolioShot = {
+  src: string;
+  alt: string;
+};
+
+const portfolioShots: PortfolioShot[] = [
+  { src: nails1, alt: 'Глянцевый нюдовый маникюр' },
+  { src: nails2, alt: 'Белый градиент с блестками' },
+  { src: nails1, alt: 'Дизайн с золотой фольгой' },
+  { src: nails2, alt: 'Классический французский маникюр' },
+  { src: nails1, alt: 'Минималистичный нюдовый дизайн' },
+  { src: nails2, alt: 'Нежный маникюр с камнями' },
+  { src: nails1, alt: 'Розовый омбре с градиентом' },
+  { src: nails2, alt: 'Лунный маникюр с акцентом' },
+  { src: nails1, alt: 'Пастельный дизайн с блестками' },
+];
+
+const chunkSize = 7;
 
 const PortfolioSection = () => {
-  const [currentImage, setCurrentImage] = useState(0);
-  
-  const portfolioImages = [
-    { src: nails1, alt: 'Дизайн ногтей 1' },
-    { src: nails2, alt: 'Дизайн ногтей 2' },
-    { src: nails1, alt: 'Дизайн ногтей 3' },
-    { src: nails2, alt: 'Дизайн ногтей 4' },
-  ];
+  const [currentSlide, setCurrentSlide] = useState(0);
 
-  const nextImage = () => {
-    setCurrentImage((prev) => (prev + 1) % portfolioImages.length);
+  const slides = useMemo(() => {
+    const totalShots = portfolioShots.length;
+
+    if (totalShots === 0) {
+      return [[]] as PortfolioShot[][];
+    }
+
+    const slideCount = totalShots > chunkSize ? Math.ceil(totalShots / chunkSize) : 1;
+
+    return Array.from({ length: slideCount }, (_, slideIndex) =>
+      Array.from({ length: chunkSize }, (_, offset) => {
+        const shotIndex = (slideIndex * chunkSize + offset) % totalShots;
+        return portfolioShots[shotIndex];
+      }),
+    );
+  }, []);
+
+  const nextSlide = () => {
+    setCurrentSlide((prev) => (prev + 1) % slides.length);
   };
 
-  const prevImage = () => {
-    setCurrentImage((prev) => (prev - 1 + portfolioImages.length) % portfolioImages.length);
+  const prevSlide = () => {
+    setCurrentSlide((prev) => (prev - 1 + slides.length) % slides.length);
   };
+
+  const slideImages = slides[currentSlide] ?? portfolioShots.slice(0, chunkSize);
+  const heroImage = slideImages[0];
+  const heroImageSrc = heroImage?.src ?? portfolioShots[0]?.src ?? '';
+  const heroImageAlt = heroImage?.alt ?? portfolioShots[0]?.alt ?? 'Работы мастера Яны';
+  const supportingImages = slideImages.slice(1);
 
   return (
-    <section id="portfolio" className="py-20 bg-background">
+    <section id="portfolio" className="bg-[#080808] py-24">
       <div className="container mx-auto px-4">
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-16 items-center">
-          {/* Left side - Video placeholder */}
-          <div className="order-2 lg:order-1">
-            <div className="relative aspect-[4/5] bg-gradient-to-br from-primary/20 to-secondary/20 rounded-3xl overflow-hidden group cursor-pointer">
-              <img 
-                src={nails1} 
-                alt="Видео портфолио" 
-                className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
-              />
-              <div className="absolute inset-0 bg-black/40 flex items-center justify-center">
-                <div className="text-center">
-                  <div className="w-20 h-20 bg-primary rounded-full flex items-center justify-center mb-4 mx-auto">
-                    <svg className="w-8 h-8 text-primary-foreground ml-1" fill="currentColor" viewBox="0 0 24 24">
-                      <path d="M8 5v14l11-7z"/>
-                    </svg>
-                  </div>
-                  <p className="text-white font-bold text-xl">ВИДЕО ПОРТФОЛИО</p>
+        <div className="max-w-4xl">
+          <h2 className="font-heading text-left text-4xl font-bold uppercase tracking-[0.2em] text-primary sm:text-5xl lg:text-7xl">
+            ПОРТФОЛИО
+          </h2>
+          <p className="mt-4 max-w-xl text-left text-xs font-semibold uppercase tracking-[0.32em] text-primary/80 sm:text-sm">
+            <span className="block">МАНИКЮР ЛЮБИМЫЙ ЖЕНСКИЙ СПОСОБ ВОССТАНОВЛЕНИЯ</span>
+            <span className="mt-1 block">ДУШЕВНОГО РАВНОВЕСИЯ</span>
+          </p>
+        </div>
+
+        <div className="relative mt-16">
+          <div className="overflow-hidden rounded-[56px] border-[3px] border-primary/60 bg-gradient-to-br from-black via-[#0b0b0b] to-black/90 p-8 shadow-[0_0_80px_rgba(255,92,158,0.25)] sm:p-10">
+            <div className="grid gap-8 lg:grid-cols-[minmax(280px,360px)_1fr] xl:grid-cols-[minmax(320px,400px)_1fr]">
+              <div className="group relative flex w-full min-h-[520px] rounded-[36px] border-[3px] border-primary/70 bg-black/70 p-4 transition-transform duration-500 hover:-translate-y-1">
+                <div className="relative flex-1 overflow-hidden rounded-[28px]">
+                  <img
+                    src={heroImageSrc}
+                    alt={heroImageAlt}
+                    className="absolute inset-0 h-full w-full object-cover transition-transform duration-1000 group-hover:scale-105"
+                  />
+                  <div className="absolute inset-0 bg-gradient-to-t from-black via-black/30 to-transparent" />
+                  <span className="absolute bottom-9 left-9 text-left text-base font-black uppercase tracking-[0.4em] text-[#ff2f5f] drop-shadow-[0_0_18px_rgba(255,47,95,0.6)] sm:text-lg lg:text-xl">
+                    ВИДЕО ПОРТФОЛИО
+                  </span>
                 </div>
               </div>
-            </div>
-          </div>
 
-          {/* Right side - Text and portfolio grid */}
-          <div className="order-1 lg:order-2 space-y-8">
-            <div className="text-center lg:text-right">
-              <h2 className="font-heading text-4xl lg:text-6xl font-bold gradient-text mb-6">
-                ПОРТФОЛИО
-              </h2>
-              <p className="text-lg text-foreground max-w-md mx-auto lg:ml-auto">
-                <span className="text-primary font-semibold">МАНИКЮР</span> ЛЮБИМЫЙ <span className="text-primary font-semibold">ЖЕНСКИЙ СПОСОБ ВОССТАНОВЛЕНИЯ</span>
-                <br />
-                <span className="text-primary font-semibold">ДУШЕВНОГО РАВНОВЕСИЯ</span>
-              </p>
-            </div>
-
-            {/* Portfolio grid with navigation */}
-            <div className="grid grid-cols-2 gap-4">
-              {portfolioImages.map((image, index) => (
-                <div 
-                  key={index}
-                  className={`relative aspect-square rounded-2xl overflow-hidden cursor-pointer transition-all duration-300 ${
-                    index === currentImage ? 'ring-2 ring-primary scale-105' : 'hover:scale-102'
-                  }`}
-                  onClick={() => setCurrentImage(index)}
-                >
-                  <img 
-                    src={image.src} 
-                    alt={image.alt}
-                    className="w-full h-full object-cover"
-                  />
-                  
-                  {/* Navigation arrows on hover */}
-                  {index === currentImage && (
-                    <div className="absolute inset-0 bg-black/20 flex items-center justify-between p-2">
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          prevImage();
-                        }}
-                        className="bg-white/20 hover:bg-white/30 text-white"
-                      >
-                        <ChevronLeft className="h-4 w-4" />
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          nextImage();
-                        }}
-                        className="bg-white/20 hover:bg-white/30 text-white"
-                      >
-                        <ChevronRight className="h-4 w-4" />
-                      </Button>
+              <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                {supportingImages.map((image, index) => (
+                  <div
+                    key={`${currentSlide}-${index + 1}-${image.alt}`}
+                    className="group relative flex w-full min-h-[160px] rounded-[28px] border-[3px] border-primary/60 bg-black/70 p-3 shadow-[0_0_30px_rgba(255,92,158,0.18)] transition-transform duration-500 hover:-translate-y-1 sm:min-h-[180px] lg:min-h-[190px]"
+                  >
+                    <div className="relative flex-1 overflow-hidden rounded-[22px]">
+                      <img
+                        src={image.src}
+                        alt={image.alt}
+                        className="absolute inset-0 h-full w-full object-cover transition-transform duration-1000 group-hover:scale-105"
+                      />
+                      <div className="absolute inset-0 bg-gradient-to-br from-white/5 via-transparent to-white/5" />
                     </div>
-                  )}
-                </div>
-              ))}
+                    <div className="pointer-events-none absolute bottom-6 right-6 flex h-11 w-11 items-center justify-center rounded-full border border-white/40 bg-black/70 text-white shadow-[0_0_18px_rgba(255,92,158,0.35)] transition-colors duration-300 group-hover:bg-primary group-hover:text-primary-foreground">
+                      <ChevronRight className="h-4 w-4" />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="mt-12 flex justify-center">
+              <span className="rounded-full border border-primary/60 px-6 py-2 text-[10px] font-semibold uppercase tracking-[0.6em] text-primary/80 sm:text-xs">
+                ЭТО БРЕНД ЯНЫ
+              </span>
             </div>
           </div>
+
+          <div className="pointer-events-none absolute inset-y-0 left-4 flex items-center">
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={prevSlide}
+              className="pointer-events-auto h-14 w-14 rounded-full border border-primary/60 bg-black/70 text-white shadow-[0_0_24px_rgba(255,92,158,0.25)] transition-colors duration-300 hover:bg-primary hover:text-primary-foreground"
+              aria-label="Предыдущий слайд портфолио"
+            >
+              <ChevronLeft className="h-6 w-6" />
+            </Button>
+          </div>
+          <div className="pointer-events-none absolute inset-y-0 right-4 flex items-center">
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={nextSlide}
+              className="pointer-events-auto h-14 w-14 rounded-full border border-primary/60 bg-black/70 text-white shadow-[0_0_24px_rgba(255,92,158,0.25)] transition-colors duration-300 hover:bg-primary hover:text-primary-foreground"
+              aria-label="Следующий слайд портфолио"
+            >
+              <ChevronRight className="h-6 w-6" />
+            </Button>
+          </div>
+        </div>
+
+        <div className="mt-10 flex items-center justify-center gap-2">
+          {slides.map((_, index) => (
+            <span
+              key={index}
+              className={`h-1.5 w-10 rounded-full transition-colors duration-300 ${
+                index === currentSlide ? 'bg-primary' : 'bg-primary/30'
+              }`}
+            />
+          ))}
         </div>
       </div>
     </section>

--- a/src/components/ServicesSection.tsx
+++ b/src/components/ServicesSection.tsx
@@ -3,16 +3,108 @@ import nails1 from '@/assets/nails-1.jpg';
 
 const ServicesSection = () => {
   const services = [
-    { name: 'НАЗВАНИЕ УСЛУГИ', price: '2000 Р.', image: nails1 },
-    { name: 'НАЗВАНИЕ УСЛУГИ', price: '2000 Р.', image: nails1 },
-    { name: 'НАЗВАНИЕ УСЛУГИ', price: '2000 Р.', image: nails1 },
-    { name: 'НАЗВАНИЕ УСЛУГИ', price: '2000 Р.', image: nails1 },
-    { name: 'ОБУЧЕНИЕ 1', price: '30 000 Р.', image: nails1 },
-    { name: 'НАЗВАНИЕ УСЛУГИ', price: '2000 Р.', image: nails1 },
-    { name: 'НАЗВАНИЕ УСЛУГИ', price: '2000 Р.', image: nails1 },
-    { name: 'НАЗВАНИЕ УСЛУГИ', price: '2000 Р.', image: nails1 },
-    { name: 'НАЗВАНИЕ УСЛУГИ', price: '2000 Р.', image: nails1 },
-    { name: 'ОБУЧЕНИЕ 2', price: '40 000 Р.', image: nails1 },
+    {
+      category: 'Снятие',
+      name: 'Снятие нарощенных ногтей',
+      price: '500 ₽',
+      image: nails1,
+    },
+    {
+      category: 'Маникюр',
+      name: 'Маникюр комбинированный',
+      price: '800 ₽',
+      image: nails1,
+    },
+    {
+      category: 'Маникюр',
+      name: 'Авторский маникюр',
+      price: '1 500 ₽',
+      image: nails1,
+    },
+    {
+      category: 'Маникюр',
+      name: 'Японский маникюр',
+      price: '1 000 ₽',
+      image: nails1,
+    },
+    {
+      category: 'Маникюр',
+      name: 'Японский маникюр мужской',
+      price: '1 100 ₽',
+      image: nails1,
+    },
+    {
+      category: 'Покрытие',
+      name: 'Маникюр с покрытием',
+      price: '1 500 ₽',
+      image: nails1,
+    },
+    {
+      category: 'Покрытие',
+      name: 'Маникюр с покрытием френч',
+      price: '1 700 ₽',
+      image: nails1,
+    },
+    {
+      category: 'Коррекция',
+      name: 'Коррекция гелем 1-3 длина',
+      price: '2 000 ₽',
+      image: nails1,
+    },
+    {
+      category: 'Коррекция',
+      name: 'Коррекция гелем 4-5 длина',
+      price: '2 300 ₽',
+      image: nails1,
+    },
+    {
+      category: 'Коррекция',
+      name: 'Коррекция гелем 5-7 длина',
+      price: '3 000 ₽',
+      image: nails1,
+    },
+    {
+      category: 'Наращивание',
+      name: 'Наращивание гелем 1-3 длина',
+      price: '2 300 ₽',
+      image: nails1,
+    },
+    {
+      category: 'Наращивание',
+      name: 'Наращивание гелем 4-5 длина',
+      price: '2 700 ₽',
+      image: nails1,
+    },
+    {
+      category: 'Наращивание',
+      name: 'Наращивание гелем 5-7 длина',
+      price: '3 000 ₽',
+      image: nails1,
+    },
+    {
+      category: 'Педикюр',
+      name: 'Педикюр обработка пальцев ног',
+      price: '1 500 ₽',
+      image: nails1,
+    },
+    {
+      category: 'Педикюр',
+      name: 'Педикюр обработка пальцев ног с покрытием',
+      price: '1 800 ₽',
+      image: nails1,
+    },
+  ];
+
+  const frameGradients = [
+    'from-brand-pink/80 via-brand-pink/20 to-transparent',
+    'from-rose-500/80 via-brand-pink/20 to-transparent',
+    'from-purple-500/80 via-rose-500/20 to-transparent',
+  ];
+
+  const panelGradients = [
+    'from-brand-pink/15 via-transparent to-transparent',
+    'from-rose-500/15 via-transparent to-transparent',
+    'from-purple-500/15 via-transparent to-transparent',
   ];
 
   return (
@@ -35,30 +127,48 @@ const ServicesSection = () => {
         </div>
 
         {/* Services Grid */}
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-6">
-          {services.map((service, index) => (
-            <div key={index} className="service-card group">
-              <div className="aspect-square overflow-hidden rounded-t-3xl">
-                <img 
-                  src={service.image} 
-                  alt={service.name}
-                  className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-300"
-                />
+        <div className="grid grid-cols-1 gap-8 md:grid-cols-3 xl:grid-cols-5">
+          {services.map((service, index) => {
+            const rowIndex = Math.floor(index / 5);
+            const frameGradient = frameGradients[rowIndex % frameGradients.length];
+            const panelGradient = panelGradients[rowIndex % panelGradients.length];
+
+            return (
+              <div
+                key={service.name}
+                className={`rounded-[34px] bg-gradient-to-br ${frameGradient} p-[1.5px]`}
+              >
+                <div className="service-card group flex h-full flex-col !border-0 !bg-background/95 !rounded-[30px]">
+                  <div className="aspect-square overflow-hidden rounded-t-[28px]">
+                    <img
+                      src={service.image}
+                      alt={service.name}
+                      className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-110"
+                    />
+                  </div>
+
+                  <div
+                    className={`flex flex-1 flex-col justify-between gap-6 rounded-b-[28px] bg-gradient-to-br ${panelGradient} p-6 text-center`}
+                  >
+                    <div className="space-y-3">
+                      {service.category && (
+                        <span className="inline-flex items-center justify-center rounded-full bg-primary/15 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-primary">
+                          {service.category}
+                        </span>
+                      )}
+                      <h3 className="font-semibold text-sm leading-tight text-foreground">
+                        {service.name}
+                      </h3>
+                      <p className="text-lg font-bold text-primary">{service.price}</p>
+                    </div>
+                    <Button className="btn-hero w-full py-2 text-sm">
+                      ЗАПИСАТЬСЯ
+                    </Button>
+                  </div>
+                </div>
               </div>
-              
-              <div className="p-6 text-center space-y-4">
-                <h3 className="font-semibold text-foreground text-sm">
-                  {service.name}
-                </h3>
-                <p className="text-primary font-bold text-lg">
-                  {service.price}
-                </p>
-                <Button className="w-full btn-hero text-sm py-2">
-                  ЗАПИСАТЬСЯ
-                </Button>
-              </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       </div>
     </section>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -7,16 +7,26 @@ import ReviewsSection from '@/components/ReviewsSection';
 import CertificatesSection from '@/components/CertificatesSection';
 import Footer from '@/components/Footer';
 
+const SectionDivider = () => (
+  <div className="h-[3px] w-full bg-[#FF62B1]" aria-hidden="true" />
+);
+
 const Index = () => {
   return (
     <div className="min-h-screen bg-background">
       <Header />
       <HeroSection />
+      <SectionDivider />
       <AboutSection />
+      <SectionDivider />
       <ServicesSection />
+      <SectionDivider />
       <PortfolioSection />
+      <SectionDivider />
       <ReviewsSection />
+      <SectionDivider />
       <CertificatesSection />
+      <SectionDivider />
       <Footer />
     </div>
   );


### PR DESCRIPTION
## Summary
- rebuild the portfolio slide markup so each group renders a hero portrait with six supporting shots laid out like the provided reference
- restyle the gallery with thick neon borders, hover motion, video caption overlay, and footer tagline to mirror the screenshot treatment
- ensure slide generation always delivers seven images per block with safe fallbacks for hero data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1bb0cea74832190c38865facd93fa