### PR TITLE
Rework certificates gallery layout

### DIFF
--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -1,61 +1,100 @@
 import yanaPortrait from '@/assets/yana-portrait.jpg';
 
 const AboutSection = () => {
+  const infoHighlights = [
+    (
+      <>
+        <span className="font-semibold text-[#FF62B1]">Я УЖЕ 15 ЛЕТ</span>{' '}
+        Я ДЕЛАЮ РУКИ И НОЖКИ МОИХ КЛИЕНТОВ НЕ ПРОСТО УХОЖЕННЫМИ, А{' '}
+        <span className="font-semibold text-[#FF62B1]">БЕЗУПРЕЧНЫМИ.</span>
+      </>
+    ),
+    (
+      <>
+        <span className="font-semibold text-[#FF62B1]">
+          ЖИВУ И РАБОТАЮ В РОСТОВЕ-НА-ДОНУ.
+        </span>
+      </>
+    ),
+    (
+      <>
+        ГЛУБОКАЯ ЭКСПЕРТИЗА ПОЗВОЛЯЕТ МНЕ НЕ ТОЛЬКО{' '}
+        <span className="font-semibold text-[#FF62B1]">ДЕЛАТЬ СЛОЖНЕЙШИЕ РАБОТЫ,</span>{' '}
+        НО И УЧИТЬ ЭТОМУ ДРУГИХ — Я С РАДОСТЬЮ ДЕЛЮСЬ СВОИМИ ЗНАНИЯМИ НА КУРСАХ И СМОГУ{' '}
+        <span className="font-semibold text-[#FF62B1]">ВАС НАУЧИТЬ ЭТОМУ С 0.</span>
+      </>
+    ),
+    (
+      <>
+        ОБОЖАЮ ВЫЗОВЫ И <span className="font-semibold text-[#FF62B1]">ТРУДНЫЕ ЗАДАЧИ!</span>{' '}
+        ЕСЛИ У ВАС ЕСТЬ <span className="font-semibold text-[#FF62B1]">ПРОБЛЕМА С НОГТЯМИ,</span>{' '}
+        КОТОРУЮ НИКТО НЕ МОЖЕТ РЕШИТЬ, — ВАМ КО МНЕ. ВМЕСТЕ НАЙДЁМ{' '}
+        <span className="font-semibold text-[#FF62B1]">РЕШЕНИЕ И СДЕЛАЕМ ВАМ НОВЫЙ ОБРАЗ ЗА 1.5 ЧАСА</span>
+      </>
+    ),
+  ];
+
   return (
-    <section id="about" className="py-20 bg-background">
-      <div className="container mx-auto px-4">
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-16 items-center">
-          {/* Left side - Decorative circles and photo */}
-          <div className="flex justify-center lg:justify-start">
-            <div className="relative">
-              {/* Decorative circles */}
-              <div className="absolute -left-20 -top-10 w-32 h-32 bg-primary/20 rounded-full"></div>
-              <div className="absolute -left-10 top-20 w-24 h-24 bg-secondary/30 rounded-full"></div>
-              <div className="absolute left-10 -top-5 w-20 h-20 bg-primary/15 rounded-full"></div>
-              
-              {/* Main photo circle */}
-              <div className="relative w-80 h-80 rounded-full overflow-hidden border-4 border-primary/30 shadow-2xl">
-                <img 
-                  src={yanaPortrait} 
-                  alt="Яна Пилит - мастер маникюра" 
-                  className="w-full h-full object-cover"
+    <section id="about" className="relative bg-background py-24">
+      <div className="absolute inset-x-0 top-0 hidden h-64 bg-gradient-to-b from-[rgba(255,98,177,0.12)] to-transparent lg:block" />
+      <div className="container relative mx-auto px-4">
+        <div className="grid items-center gap-16 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,1fr)]">
+          <div className="order-2 flex justify-center lg:order-1 lg:justify-start">
+            <div className="relative flex h-[22rem] w-[22rem] items-center justify-center sm:h-[26rem] sm:w-[26rem] lg:h-[30rem] lg:w-[30rem]">
+              <div
+                className="absolute -inset-[28%] rounded-full bg-[radial-gradient(circle,_rgba(255,98,177,0.26)_0%,_rgba(9,2,14,0)_70%)]"
+                aria-hidden="true"
+              />
+              <div
+                className="absolute -inset-[18%] rounded-full border border-[rgba(255,98,177,0.35)]"
+                aria-hidden="true"
+              />
+              <div
+                className="absolute -inset-[10%] rounded-full border border-[rgba(255,98,177,0.22)]"
+                aria-hidden="true"
+              />
+              <div
+                className="absolute inset-0 rounded-full bg-[radial-gradient(circle_at_top_left,_rgba(255,98,177,0.3),_rgba(11,4,15,0)_68%)]"
+                aria-hidden="true"
+              />
+
+              <div className="relative h-full w-full overflow-hidden rounded-full border-[6px] border-[#FF62B1] bg-[#0b050d] shadow-[0_45px_95px_-40px_rgba(255,98,177,0.85)]">
+                <img
+                  src={yanaPortrait}
+                  alt="Яна Пилит - мастер маникюра"
+                  className="h-full w-full object-cover"
                 />
-                <div className="absolute inset-0 bg-gradient-to-br from-primary/20 to-transparent"></div>
-              </div>
-              
-              {/* Decorative text around circle */}
-              <div className="absolute inset-0 flex items-center justify-center">
-                <div className="w-96 h-96 rounded-full border border-primary/20 flex items-center justify-center">
-                  <div className="text-primary/60 text-sm font-medium tracking-widest transform -rotate-12">
-                    Я Н А &nbsp; П И Л И Т &nbsp; / &nbsp; Я Н А &nbsp; П И Л И Т
-                  </div>
-                </div>
+                <div className="absolute inset-0 bg-gradient-to-br from-transparent via-transparent to-[rgba(9,0,12,0.45)]" aria-hidden="true" />
               </div>
             </div>
           </div>
 
-          {/* Right side - Text content */}
-          <div className="space-y-8">
-            <h2 className="font-heading text-4xl lg:text-6xl font-bold gradient-text mb-8">
-              МЕНЯ ЗОВУТ ЯНА
-            </h2>
-            
-            <div className="border-2 border-primary p-8 rounded-2xl space-y-6 text-lg leading-relaxed">
-              <p className="text-foreground">
-                <span className="text-primary font-semibold">Я УЖЕ 15 ЛЕТ</span> Я ДЕЛАЮ РУКИ И НОЖКИ МОИХ КЛИЕНТОВ НЕ ПРОСТО УХОЖЕННЫМИ, А <span className="text-primary font-semibold">БЕЗУПРЕЧНЫМИ.</span>
-              </p>
-              
-              <p className="text-foreground">
-                <span className="text-primary font-semibold">ЖИВУ И РАБОТАЮ В РОСТОВЕ-НА-ДОНУ.</span>
-              </p>
-              
-              <p className="text-foreground">
-                ГЛУБОКАЯ ЭКСПЕРТИЗА ПОЗВОЛЯЕТ МНЕ НЕ ТОЛЬКО <span className="text-primary font-semibold">ДЕЛАТЬ СЛОЖНЕЙШИЕ РАБОТЫ,</span> НО И УЧИТЬ ЭТОМУ ДРУГИХ — Я С РАДОСТЬЮ ДЕЛЮСЬ СВОИМИ ЗНАНИЯМИ НА КУРСАХ И СМОГУ <span className="text-primary font-semibold">ВАС НАУЧИТЬ ЭТОМУ С 0.</span>
-              </p>
-              
-              <p className="text-foreground">
-                ОБОЖАЮ ВЫЗОВЫ И <span className="text-primary font-semibold">ТРУДНЫЕ ЗАДАЧИ!</span> ЕСЛИ У ВАС ЕСТЬ <span className="text-primary font-semibold">ПРОБЛЕМА С НОГТЯМИ,</span> КОТОРУЮ НИКТО НЕ МОЖЕТ РЕШИТЬ, — ВАМ КО МНЕ. ВМЕСТЕ НАЙДЁМ <span className="text-primary font-semibold">РЕШЕНИЕ И СДЕЛАЕМ ВАМ НОВЫЙ ОБРАЗ ЗА 1.5 ЧАСА</span>
-              </p>
+          <div className="order-1 space-y-10 text-left lg:order-2">
+            <div className="space-y-4">
+              <p className="text-sm uppercase tracking-[0.48em] text-[rgba(255,98,177,0.7)]">Мастер ногтевого сервиса</p>
+              <h2 className="font-heading text-4xl font-bold uppercase text-foreground sm:text-5xl lg:text-6xl">
+                МЕНЯ ЗОВУТ <span className="text-[#FF62B1]">ЯНА</span>
+              </h2>
+            </div>
+
+            <div className="flex justify-center lg:justify-start">
+              <div className="relative w-full max-w-[34rem]">
+                <div
+                  className="pointer-events-none absolute -inset-6 hidden rounded-[3rem] border border-[rgba(255,98,177,0.32)] sm:block"
+                  aria-hidden="true"
+                />
+                <div
+                  className="pointer-events-none absolute -inset-12 hidden rounded-[3rem] border border-[rgba(255,98,177,0.18)] lg:block"
+                  aria-hidden="true"
+                />
+                <div className="relative overflow-hidden rounded-[3rem] border-[3px] border-[rgba(255,98,177,0.68)] bg-[rgba(12,3,16,0.78)] px-8 py-10 text-lg leading-relaxed text-foreground shadow-[0_35px_90px_-45px_rgba(255,98,177,0.75)] backdrop-blur-sm sm:px-12 sm:py-14">
+                  <div className="space-y-6">
+                    {infoHighlights.map((content, index) => (
+                      <p key={index}>{content}</p>
+                    ))}
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/CertificatesSection.tsx
+++ b/src/components/CertificatesSection.tsx
@@ -8,26 +8,28 @@ const CertificatesSection = () => {
     { name: 'НАЗВАНИЕ 4', image: certificate1 },
     { name: 'НАЗВАНИЕ 5', image: certificate1 },
     { name: 'НАЗВАНИЕ 6', image: certificate1 },
+    { name: 'НАЗВАНИЕ 7', image: certificate1 },
+    { name: 'НАЗВАНИЕ 8', image: certificate1 },
   ];
 
   return (
-    <section id="certificates" className="py-20 bg-background">
+    <section id="certificates" className="py-24 bg-background">
       <div className="container mx-auto px-4">
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-16">
-          {/* Certificates grid - takes 2/3 of the space */}
-          <div className="lg:col-span-2 order-2 lg:order-1">
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        <div className="flex flex-col lg:flex-row lg:items-start gap-12 xl:gap-20">
+          {/* Certificates grid */}
+          <div className="flex-1 order-2 lg:order-1">
+            <div className="grid grid-cols-2 sm:grid-cols-3 xl:grid-cols-4 gap-6 xl:gap-8">
               {certificates.map((cert, index) => (
                 <div key={index} className="certificate-card group">
                   <div className="aspect-[3/4] overflow-hidden rounded-t-2xl">
-                    <img 
-                      src={cert.image} 
+                    <img
+                      src={cert.image}
                       alt={cert.name}
                       className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-300"
                     />
                   </div>
                   <div className="p-4 text-center">
-                    <h3 className="font-semibold text-foreground text-sm">
+                    <h3 className="font-semibold text-foreground text-sm tracking-wide uppercase">
                       {cert.name}
                     </h3>
                   </div>
@@ -37,13 +39,15 @@ const CertificatesSection = () => {
           </div>
 
           {/* Right side - Header text */}
-          <div className="order-1 lg:order-2 space-y-8">
-            <h2 className="font-heading text-4xl lg:text-6xl font-bold gradient-text text-center lg:text-right">
-              СЕРТИФИКАТЫ
-            </h2>
-            
-            <div className="space-y-6 text-lg leading-relaxed text-center lg:text-right">
-              <p className="text-foreground">
+          <div className="order-1 lg:order-2 lg:max-w-sm xl:max-w-md lg:pt-4">
+            <div className="flex flex-col items-center lg:items-end gap-6 text-center lg:text-right">
+              <div className="space-y-3">
+                <span className="inline-block text-xs tracking-[0.6em] uppercase text-muted-foreground">достижения</span>
+                <h2 className="font-heading text-4xl lg:text-5xl xl:text-6xl font-bold gradient-text">
+                  СЕРТИФИКАТЫ
+                </h2>
+              </div>
+              <p className="text-lg leading-relaxed text-foreground">
                 <span className="text-primary font-semibold">Я ГОРЖУСЬ КАЖДЫМ ИЗ ЭТИХ СЕРТИФИКАТОВ</span> — ОНИ НАПОМИНАЮТ МНЕ О ПУТИ, КОТОРЫЙ Я ПРОШЛА, ЧТОБЫ <span className="text-primary font-semibold">ДАВАТЬ ВАМ ТОЛЬКО ЛУЧШЕЕ.</span>
               </p>
             </div>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -10,58 +10,68 @@ const HeroSection = () => {
   };
 
   return (
-    <section className="min-h-screen flex items-center justify-center relative overflow-hidden bg-background">
-      <div className="container mx-auto px-4 grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
-        {/* Left side - Text content */}
-        <div className="text-left space-y-8 animate-slide-up">
-          <h1 className="font-heading text-5xl lg:text-7xl font-bold leading-tight">
-            <span className="gradient-text">КРАСИВЫЕ НОГТИ —</span>
-            <br />
-            <span className="gradient-text">ЭТО ПРОСТО</span>
-          </h1>
-          
-          <div className="space-y-4 text-lg lg:text-xl">
-            <p className="text-foreground">
-              ЕСЛИ ВЫ ИСКАЛИ <span className="text-primary font-semibold">ЛУЧШЕГО МАСТЕРА</span>
-            </p>
-            <p className="text-foreground">
-              ПО УХОДУ ЗА СВОИМИ НОГТЯМИ В
-            </p>
-            <p className="text-foreground">
-              ГОРОДЕ
-            </p>
-            <p className="text-primary text-3xl font-bold font-heading">
-              РОСТОВ - НА - ДОНУ
-            </p>
-            <p className="text-foreground">
-              ТО ВЫ ЕГО НАШЛИ
-            </p>
-          </div>
+    <section className="relative isolate flex min-h-screen items-center overflow-hidden bg-[#050505]">
+      <div className="absolute inset-0">
+        <div className="absolute inset-0 bg-[#050505]" aria-hidden="true" />
+        <img
+          src={pantherHero}
+          alt=""
+          aria-hidden="true"
+          className="pointer-events-none absolute right-[-12%] top-1/2 hidden h-[125%] max-w-none -translate-y-1/2 object-contain md:block"
+        />
+        <img
+          src={pantherHero}
+          alt=""
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 block h-full w-full object-cover object-right opacity-30 md:hidden"
+        />
+        <div
+          className="absolute inset-0 bg-gradient-to-r from-[#050505] via-[#050505]/95 to-transparent"
+          aria-hidden="true"
+        />
+      </div>
 
-          <Button 
-            onClick={scrollToContact}
-            className="btn-hero text-xl px-12 py-6 mt-8"
-          >
-            ЗАПИСАТЬСЯ
-          </Button>
-        </div>
-
-        {/* Right side - Panther image */}
-        <div className="flex justify-center lg:justify-end animate-float">
-          <div className="relative">
-            <img 
-              src={pantherHero} 
-              alt="Элегантная пантера - символ красоты и изящества" 
-              className="w-full max-w-lg h-auto object-cover rounded-3xl shadow-2xl"
-            />
-            <div className="absolute inset-0 bg-gradient-to-br from-primary/20 to-transparent rounded-3xl"></div>
+      <div className="container relative z-10 mx-auto px-4 py-20 lg:py-32">
+        <div className="max-w-xl rounded-[40px] border border-primary/20 bg-background/80 p-8 sm:p-12 shadow-2xl backdrop-blur-md text-left animate-slide-up">
+          <div className="space-y-6">
+            <p className="text-sm font-semibold uppercase tracking-[0.55em] text-muted-foreground">
+              ЯНА ПИЛИТ
+            </p>
+            <h1 className="font-heading text-4xl sm:text-5xl lg:text-6xl font-bold leading-tight uppercase">
+              <span className="gradient-text">КРАСИВЫЕ НОГТИ —</span>
+              <br />
+              <span className="gradient-text">ЭТО ПРОСТО</span>
+            </h1>
+            <div className="space-y-2 text-lg sm:text-xl font-medium text-foreground">
+              <p>
+                ЕСЛИ ВЫ ИСКАЛИ{' '}
+                <span className="text-primary font-semibold">ЛУЧШЕГО МАСТЕРА</span>
+              </p>
+              <p>ПО УХОДУ ЗА СВОИМИ НОГТЯМИ В</p>
+              <p>ГОРОДЕ</p>
+              <p className="text-primary text-3xl font-bold font-heading tracking-wide">
+                РОСТОВ - НА - ДОНУ
+              </p>
+              <p>ТО ВЫ ЕГО НАШЛИ</p>
+            </div>
+            <Button
+              onClick={scrollToContact}
+              className="btn-hero text-lg sm:text-xl px-10 sm:px-12 py-5 sm:py-6 mt-4"
+            >
+              ЗАПИСАТЬСЯ
+            </Button>
           </div>
         </div>
       </div>
 
-      {/* Decorative background elements */}
-      <div className="absolute top-20 left-10 w-20 h-20 bg-primary/10 rounded-full blur-xl animate-pulse"></div>
-      <div className="absolute bottom-20 right-10 w-32 h-32 bg-secondary/10 rounded-full blur-xl animate-pulse delay-1000"></div>
+      <div
+        className="absolute -left-24 top-24 hidden h-64 w-64 rounded-full bg-primary/20 blur-3xl md:block"
+        aria-hidden="true"
+      />
+      <div
+        className="absolute bottom-10 left-1/3 h-40 w-40 rounded-full bg-secondary/30 blur-3xl"
+        aria-hidden="true"
+      />
     </section>
   );
 };

--- a/src/components/PortfolioSection.tsx
+++ b/src/components/PortfolioSection.tsx
@@ -1,110 +1,177 @@
 import { useState } from 'react';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
-import { Button } from '@/components/ui/button';
+import { ChevronLeft, ChevronRight, Play } from 'lucide-react';
+
 import nails1 from '@/assets/nails-1.jpg';
 import nails2 from '@/assets/nails-2.jpg';
 
-const PortfolioSection = () => {
-  const [currentImage, setCurrentImage] = useState(0);
-  
-  const portfolioImages = [
-    { src: nails1, alt: 'Дизайн ногтей 1' },
-    { src: nails2, alt: 'Дизайн ногтей 2' },
-    { src: nails1, alt: 'Дизайн ногтей 3' },
-    { src: nails2, alt: 'Дизайн ногтей 4' },
-  ];
+type PortfolioShot = {
+  src: string;
+  alt: string;
+};
 
-  const nextImage = () => {
-    setCurrentImage((prev) => (prev + 1) % portfolioImages.length);
+type PortfolioCategory = {
+  key: string;
+  title: string;
+  shots: PortfolioShot[];
+};
+
+const portfolioCategories: PortfolioCategory[] = [
+  {
+    key: 'single-color',
+    title: 'SINGLE COLOR',
+    shots: [
+      { src: nails1, alt: 'Глянцевый однотонный маникюр с нюдовым покрытием' },
+      { src: nails2, alt: 'Однотонный маникюр с мягким голубым переливом' },
+      { src: nails1, alt: 'Минималистичный однотонный маникюр с блеском' },
+    ],
+  },
+  {
+    key: 'french',
+    title: 'FRENCH MANICURE',
+    shots: [
+      { src: nails2, alt: 'Классический французский маникюр с акцентами' },
+      { src: nails1, alt: 'Французский маникюр с прозрачной базой' },
+      { src: nails2, alt: 'Современный френч в холодной палитре' },
+    ],
+  },
+  {
+    key: 'extensions',
+    title: 'EXTENSIONS',
+    shots: [
+      { src: nails1, alt: 'Наращенные ногти с глянцевым покрытием' },
+      { src: nails2, alt: 'Миндалевидные наращенные ногти с дизайном' },
+      { src: nails1, alt: 'Длина ballerina с нюдовым наращиванием' },
+    ],
+  },
+  {
+    key: 'custom',
+    title: 'CUSTOM MANICURE',
+    shots: [
+      { src: nails2, alt: 'Индивидуальный дизайн с блестящим декором' },
+      { src: nails1, alt: 'Авторский маникюр с золотой фольгой' },
+      { src: nails2, alt: 'Контрастный кастомный маникюр с акцентом' },
+    ],
+  },
+];
+
+const PortfolioSection = () => {
+  const [activeShots, setActiveShots] = useState<number[]>(() =>
+    portfolioCategories.map(() => 0),
+  );
+
+  const showPreviousShot = (categoryIndex: number) => {
+    setActiveShots((prev) => {
+      const next = [...prev];
+      const shots = portfolioCategories[categoryIndex]?.shots ?? [];
+      const total = shots.length;
+
+      if (total === 0) {
+        next[categoryIndex] = 0;
+        return next;
+      }
+
+      next[categoryIndex] = (next[categoryIndex] - 1 + total) % total;
+      return next;
+    });
   };
 
-  const prevImage = () => {
-    setCurrentImage((prev) => (prev - 1 + portfolioImages.length) % portfolioImages.length);
+  const showNextShot = (categoryIndex: number) => {
+    setActiveShots((prev) => {
+      const next = [...prev];
+      const shots = portfolioCategories[categoryIndex]?.shots ?? [];
+      const total = shots.length;
+
+      if (total === 0) {
+        next[categoryIndex] = 0;
+        return next;
+      }
+
+      next[categoryIndex] = (next[categoryIndex] + 1) % total;
+      return next;
+    });
   };
 
   return (
-    <section id="portfolio" className="py-20 bg-background">
-      <div className="container mx-auto px-4">
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-16 items-center">
-          {/* Left side - Video placeholder */}
-          <div className="order-2 lg:order-1">
-            <div className="relative aspect-[4/5] bg-gradient-to-br from-primary/20 to-secondary/20 rounded-3xl overflow-hidden group cursor-pointer">
-              <img 
-                src={nails1} 
-                alt="Видео портфолио" 
-                className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+    <section id="portfolio" className="bg-[#080808] py-24">
+      <div className="container mx-auto px-4 lg:px-8">
+        <div className="grid items-stretch gap-12 lg:grid-cols-[minmax(380px,1.02fr)_minmax(420px,1.18fr)] lg:gap-16 xl:grid-cols-[minmax(420px,1.05fr)_minmax(500px,1.25fr)] xl:gap-20">
+          <div className="group relative flex w-full items-stretch justify-center lg:h-full">
+            <div className="relative w-full min-h-[520px] overflow-hidden rounded-[48px] border-[3px] border-primary/70 bg-black/70 shadow-[0_0_70px_rgba(255,92,158,0.3)] lg:h-full lg:min-h-0">
+              <img
+                src={nails2}
+                alt="Видео отзыв о маникюре"
+                className="absolute inset-0 h-full w-full object-cover transition-transform duration-700 group-hover:scale-[1.04]"
               />
-              <div className="absolute inset-0 bg-black/40 flex items-center justify-center">
-                <div className="text-center">
-                  <div className="w-20 h-20 bg-primary rounded-full flex items-center justify-center mb-4 mx-auto">
-                    <svg className="w-8 h-8 text-primary-foreground ml-1" fill="currentColor" viewBox="0 0 24 24">
-                      <path d="M8 5v14l11-7z"/>
-                    </svg>
-                  </div>
-                  <p className="text-white font-bold text-xl">ВИДЕО ПОРТФОЛИО</p>
-                </div>
-              </div>
+              <div className="absolute inset-0 bg-gradient-to-t from-black via-black/40 to-transparent" />
+              <button
+                type="button"
+                className="absolute left-1/2 top-1/2 flex h-20 w-20 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border border-white/40 bg-black/70 text-white shadow-[0_0_30px_rgba(255,92,158,0.45)] backdrop-blur-sm transition-colors duration-300 hover:bg-primary hover:text-primary-foreground"
+              >
+                <Play className="h-6 w-6" />
+              </button>
+              <span className="absolute bottom-8 left-8 text-left text-base font-black uppercase tracking-[0.4em] text-[#ff2f5f] drop-shadow-[0_0_18px_rgba(255,47,95,0.6)] sm:text-lg lg:text-xl">
+                VIDEO REVIEW
+              </span>
             </div>
           </div>
 
-          {/* Right side - Text and portfolio grid */}
-          <div className="order-1 lg:order-2 space-y-8">
-            <div className="text-center lg:text-right">
-              <h2 className="font-heading text-4xl lg:text-6xl font-bold gradient-text mb-6">
-                ПОРТФОЛИО
-              </h2>
-              <p className="text-lg text-foreground max-w-md mx-auto lg:ml-auto">
-                <span className="text-primary font-semibold">МАНИКЮР</span> ЛЮБИМЫЙ <span className="text-primary font-semibold">ЖЕНСКИЙ СПОСОБ ВОССТАНОВЛЕНИЯ</span>
-                <br />
-                <span className="text-primary font-semibold">ДУШЕВНОГО РАВНОВЕСИЯ</span>
-              </p>
-            </div>
+          <div className="flex w-full flex-col items-end text-right">
+            <h2 className="font-heading text-4xl font-bold uppercase tracking-[0.2em] text-primary sm:text-5xl lg:text-6xl">
+              PORTFOLIO
+            </h2>
+            <p className="mt-4 max-w-md text-xs font-semibold tracking-[0.26em] text-primary/85 sm:text-sm">
+              manicure: a woman's favorite way to restore peace of mind.
+            </p>
 
-            {/* Portfolio grid with navigation */}
-            <div className="grid grid-cols-2 gap-4">
-              {portfolioImages.map((image, index) => (
-                <div 
-                  key={index}
-                  className={`relative aspect-square rounded-2xl overflow-hidden cursor-pointer transition-all duration-300 ${
-                    index === currentImage ? 'ring-2 ring-primary scale-105' : 'hover:scale-102'
-                  }`}
-                  onClick={() => setCurrentImage(index)}
-                >
-                  <img 
-                    src={image.src} 
-                    alt={image.alt}
-                    className="w-full h-full object-cover"
-                  />
-                  
-                  {/* Navigation arrows on hover */}
-                  {index === currentImage && (
-                    <div className="absolute inset-0 bg-black/20 flex items-center justify-between p-2">
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          prevImage();
-                        }}
-                        className="bg-white/20 hover:bg-white/30 text-white"
-                      >
-                        <ChevronLeft className="h-4 w-4" />
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          nextImage();
-                        }}
-                        className="bg-white/20 hover:bg-white/30 text-white"
-                      >
-                        <ChevronRight className="h-4 w-4" />
-                      </Button>
+            <div className="mt-14 grid w-full gap-7 sm:grid-cols-2">
+              {portfolioCategories.map((category, index) => {
+                const shots = category.shots;
+                const currentIndex = activeShots[index] ?? 0;
+                const currentShot = shots[currentIndex] ?? shots[0];
+
+                return (
+                  <div
+                    key={category.key}
+                    className="group relative flex min-h-[220px] flex-col overflow-hidden rounded-[34px] border-[3px] border-primary/65 bg-black/70 shadow-[0_0_42px_rgba(255,92,158,0.26)] sm:min-h-[240px]"
+                  >
+                    <div className="relative flex-1 overflow-hidden">
+                      {currentShot ? (
+                        <img
+                          src={currentShot.src}
+                          alt={currentShot.alt}
+                          className="absolute inset-0 h-full w-full object-cover transition-transform duration-700 group-hover:scale-[1.05]"
+                        />
+                      ) : null}
+                      <div className="absolute inset-0 bg-gradient-to-br from-black/25 via-transparent to-black/40" />
                     </div>
-                  )}
-                </div>
-              ))}
+
+                    <div className="absolute inset-x-0 top-0 flex items-center justify-between bg-gradient-to-b from-black/75 via-black/20 to-transparent px-6 py-4">
+                      <span className="text-left text-sm font-black uppercase tracking-[0.28em] text-white sm:text-base">
+                        {category.title}
+                      </span>
+                    </div>
+
+                    <div className="pointer-events-none absolute inset-x-0 bottom-0 flex items-center justify-between px-6 pb-6">
+                      <button
+                        type="button"
+                        onClick={() => showPreviousShot(index)}
+                        className="pointer-events-auto flex h-12 w-12 items-center justify-center rounded-full border border-white/40 bg-black/70 text-white shadow-[0_0_24px_rgba(255,92,158,0.35)] transition-colors duration-300 hover:bg-primary hover:text-primary-foreground"
+                        aria-label={`Предыдущая работа категории ${category.title}`}
+                      >
+                        <ChevronLeft className="h-5 w-5" />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => showNextShot(index)}
+                        className="pointer-events-auto flex h-12 w-12 items-center justify-center rounded-full border border-white/40 bg-black/70 text-white shadow-[0_0_24px_rgba(255,92,158,0.35)] transition-colors duration-300 hover:bg-primary hover:text-primary-foreground"
+                        aria-label={`Следующая работа категории ${category.title}`}
+                      >
+                        <ChevronRight className="h-5 w-5" />
+                      </button>
+                    </div>
+                  </div>
+                );
+              })}
             </div>
           </div>
         </div>

--- a/src/components/ReviewsSection.tsx
+++ b/src/components/ReviewsSection.tsx
@@ -1,81 +1,204 @@
+import { useEffect, useRef } from 'react';
+
+const highlightPoints = [
+  {
+    title: 'МОЯ МОТИВАЦИЯ',
+    description: 'ВАШИ СЛОВА — МОЯ САМАЯ ЦЕННАЯ НАГРАДА. КАЖДЫЙ ТЕПЛЫЙ КОММЕНТАРИЙ ПОМОГАЕТ СТАТЬ ЕЩЁ ЛУЧШЕ ДЛЯ ВАС.'
+  },
+  {
+    title: 'ИСТОРИИ И ЭМОЦИИ',
+    description: 'ЗДЕСЬ СОБРАНЫ ИСКРЕННИЕ ЭМОЦИИ И ВПЕЧАТЛЕНИЯ ТЕХ, КОМУ Я ПОМОГЛА ОБРЕСТИ НЕ ПРОСТО КРАСОТУ, А УВЕРЕННОСТЬ В СЕБЕ.'
+  },
+  {
+    title: 'ДОВЕРИЕ',
+    description: 'СПАСИБО, ЧТО ДОВЕРЯЕТЕ МНЕ СВОИ РУКИ, ВРЕМЯ И ОЖИДАНИЯ. ДЛЯ МЕНЯ ЭТО САМАЯ ВЫСОКАЯ ОТВЕТСТВЕННОСТЬ И ЧЕСТЬ.'
+  },
+  {
+    title: 'ВДОХНОВЕНИЕ',
+    description: 'КАЖДЫЙ ОТЗЫВ СОГРЕВАЕТ СЕРДЦЕ И ВДОХНОВЛЯЕТ НА НОВЫЕ СВЕРШЕНИЯ, НОВЫЕ ДИЗАЙНЫ И ЗАБОТУ О ВАС.'
+  }
+];
+
+const reviews = [
+  {
+    code: 'KL.01',
+    name: 'ЮЛЯ',
+    text: 'ЭТО ШЕДЕВР! Я ДАЖЕ ПРЕДСТАВИТЬ НЕ МОГЛА, ЧТО МОИ РУКИ МОГУТ ВЫГЛЯДЕТЬ НАСТОЛЬКО УХОЖЕННО И СТИЛЬНО.'
+  },
+  {
+    code: 'KL.02',
+    name: 'АННА',
+    text: 'КАЖДЫЙ ВИЗИТ — ОТДЫХ И ДЛЯ ДУШИ, И ДЛЯ РУК. Я ВЫХОЖУ С НОВЫМ НАСТРОЕНИЕМ И ЧУВСТВОМ, ЧТО О МНЕ ПОЗАБОТИЛИСЬ.'
+  },
+  {
+    code: 'KL.03',
+    name: 'СВЕТА',
+    text: 'ЯНА СРАЗУ ПОНИМАЕТ, ЧТО МНЕ НУЖНО. ДИЗАЙН ВСЕГДА ТОЧНО В МОЁМ СТИЛЕ, А ПОКРЫТИЕ ДЕРЖИТСЯ ДО ПОСЛЕДНЕГО ДНЯ.'
+  },
+  {
+    code: 'KL.04',
+    name: 'КАТЯ',
+    text: 'БЛАГОДАРЯ ТЕБЕ Я НАЧАЛА ВЕРИТЬ, ЧТО РУКИ МОГУТ ВЫГЛЯДЕТЬ АККУРАТНО ВСЕГДА. ЭТО ОЧЕНЬ ПОДНИМАЕТ УВЕРЕННОСТЬ.'
+  },
+  {
+    code: 'KL.05',
+    name: 'НАТАША',
+    text: 'УЮТНО, СПОКОЙНО, ВНИМАТЕЛЬНО — ВСЁ, ЧТО ХОЧЕТСЯ ЧУВСТВОВАТЬ У ЛЮБИМОГО МАСТЕРА. СПАСИБО ЗА ЭТУ АТМОСФЕРУ.'
+  },
+  {
+    code: 'KL.06',
+    name: 'ПОЛИНА',
+    text: 'ТОЧНОСТЬ ВО ВСЁМ: И ФОРМА, И ЦВЕТ, И УХОД. Я ВСЕГДА ПОЛУЧАЮ ТО, ЧТО ЗАПЛАНИРОВАЛА, И ДАЖЕ БОЛЬШЕ.'
+  },
+  {
+    code: 'KL.07',
+    name: 'ЛЕНА',
+    text: 'С ПЕРВОГО ВИЗИТА ПОНЯЛА, ЧТО ОСТАНУСЬ. ЛАК ЛОЖИТСЯ ИДЕАЛЬНО, А РУКИ НЕ УСТАЮТ ДАЖЕ ПРИ ДЛИННОЙ РАБОТЕ.'
+  },
+  {
+    code: 'KL.08',
+    name: 'ДАРЬЯ',
+    text: 'ВСЕГДА ЧИСТО, АККУРАТНО И БЕЗОПАСНО. ЧУВСТВУЮ СЕБЯ В ЗАБОТЕ И ЛЮБВИ, И РЕЗУЛЬТАТЫ ВСЕГДА ВОСХИЩАЮТ.'
+  },
+  {
+    code: 'KL.09',
+    name: 'ВИКТОРИЯ',
+    text: 'ТЫ УМЕЕШЬ СЛУШАТЬ ЖЕЛАНИЯ И ПРЕДЛАГАТЬ СВОИ ИДЕИ. ИТОГ ВСЕГДА ЛУЧШЕ, ЧЕМ Я СЕБЕ ПРЕДСТАВЛЯЛА!'
+  }
+];
+
+const reviewColumns = [
+  reviews.slice(0, 3),
+  reviews.slice(3, 6),
+  reviews.slice(6, 9)
+];
+
+const columnDirections: Array<'up' | 'down'> = ['up', 'down', 'up'];
+const columnDurations = ['26s', '32s', '28s'];
+
 const ReviewsSection = () => {
-  const reviews = [
-    {
-      name: 'ЮЛЯ',
-      text: 'ЭТО ШЕДЕВР! Я ДАЖЕ ПРЕДСТАВИТЬ НЕ МОГЛА, ЧТО МОИ РУКИ МОГУТ ВЫГЛЯДЕТЬ НАСТОЛЬКО УХОЖЕННО И СТИЛЬНО.'
-    },
-    {
-      name: 'ЮЛЯ',
-      text: 'ЭТО ШЕДЕВР! Я ДАЖЕ ПРЕДСТАВИТЬ НЕ МОГЛА, ЧТО МОИ РУКИ МОГУТ ВЫГЛЯДЕТЬ НАСТОЛЬКО УХОЖЕННО И СТИЛЬНО.'
-    },
-    {
-      name: 'ЮЛЯ',
-      text: 'ЭТО ШЕДЕВР! Я ДАЖЕ ПРЕДСТАВИТЬ НЕ МОГЛА, ЧТО МОИ РУКИ МОГУТ ВЫГЛЯДЕТЬ НАСТОЛЬКО УХОЖЕННО И СТИЛЬНО.'
-    },
-    {
-      name: 'ЮЛЯ',
-      text: 'ЭТО ШЕДЕВР! Я ДАЖЕ ПРЕДСТАВИТЬ НЕ МОГЛА, ЧТО МОИ РУКИ МОГУТ ВЫГЛЯДЕТЬ НАСТОЛЬКО УХОЖЕННО И СТИЛЬНО.'
-    },
-    {
-      name: 'ЮЛЯ',
-      text: 'ЭТО ШЕДЕВР! Я ДАЖЕ ПРЕДСТАВИТЬ НЕ МОГЛА, ЧТО МОИ РУКИ МОГУТ ВЫГЛЯДЕТЬ НАСТОЛЬКО УХОЖЕННО И СТИЛЬНО.'
-    },
-    {
-      name: 'ЮЛЯ',
-      text: 'ЭТО ШЕДЕВР! Я ДАЖЕ ПРЕДСТАВИТЬ НЕ МОГЛА, ЧТО МОИ РУКИ МОГУТ ВЫГЛЯДЕТЬ НАСТОЛЬКО УХОЖЕННО И СТИЛЬНО.'
-    },
-  ];
+  const headingRef = useRef<HTMLHeadingElement | null>(null);
+  const columnsRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const updateMaskOffset = () => {
+      if (!headingRef.current || !columnsRef.current) {
+        return;
+      }
+
+      const headingRect = headingRef.current.getBoundingClientRect();
+      const columnsRect = columnsRef.current.getBoundingClientRect();
+      const offset = Math.max(0, headingRect.bottom - columnsRect.top);
+      const cappedOffset = Math.min(offset, 480);
+
+      columnsRef.current.style.setProperty('--review-mask-top', `${cappedOffset}px`);
+    };
+
+    updateMaskOffset();
+
+    if (typeof window !== 'undefined') {
+      window.addEventListener('resize', updateMaskOffset);
+    }
+
+    let resizeObserver: ResizeObserver | undefined;
+
+    if (typeof ResizeObserver !== 'undefined') {
+      resizeObserver = new ResizeObserver(() => updateMaskOffset());
+      if (headingRef.current) {
+        resizeObserver.observe(headingRef.current);
+      }
+      if (columnsRef.current) {
+        resizeObserver.observe(columnsRef.current);
+      }
+    }
+
+    return () => {
+      if (typeof window !== 'undefined') {
+        window.removeEventListener('resize', updateMaskOffset);
+      }
+      resizeObserver?.disconnect();
+    };
+  }, []);
 
   return (
-    <section id="reviews" className="py-20 bg-background overflow-hidden">
+    <section id="reviews" className="bg-background py-24 overflow-hidden">
       <div className="container mx-auto px-4">
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-16">
+        <div className="grid grid-cols-1 xl:grid-cols-[0.9fr_1.1fr] gap-16 xl:items-end">
           {/* Left side - Header text */}
-          <div className="space-y-8">
-            <h2 className="font-heading text-4xl lg:text-6xl font-bold gradient-text">
-              ОТЗЫВЫ
-            </h2>
-            
-            <div className="space-y-6 text-lg leading-relaxed">
-              <p className="text-foreground">
-                <span className="text-primary font-semibold">ВАШИ СЛОВА — МОЯ САМАЯ ЦЕННАЯ НАГРАДА</span> И ЛУЧШАЯ МОТИВАЦИЯ.
+          <div className="space-y-10 self-start">
+            <div className="space-y-4 max-w-xl">
+              <span className="text-xs font-semibold uppercase tracking-[0.4em] text-primary/80">
+                ЖИВЫЕ ЭМОЦИИ
+              </span>
+              <h2
+                ref={headingRef}
+                className="font-heading text-4xl lg:text-6xl font-bold gradient-text"
+              >
+                ОТЗЫВЫ
+              </h2>
+              <p className="text-lg leading-relaxed text-muted-foreground">
+                СОБИРАЮ И БЕРЕЖНО ХРАНЮ КАЖДОЕ СЛОВО. ВМЕСТЕ МЫ СОЗДАЁМ НЕ ПРОСТО ДИЗАЙНЫ, А ИСТОРИИ ДОВЕРИЯ И КРАСОТЫ.
               </p>
-              
-              <p className="text-foreground">
-                ЗДЕСЬ СОБРАНЫ ИСКРЕННИЕ ИСТОРИИ И ЭМОЦИИ ТЕХ, КОМУ Я <span className="text-primary font-semibold">ПОМОГЛА ОБРЕСТИ НЕ ПРОСТО КРАСОТУ, А УВЕРЕННОСТЬ В СЕБЕ.</span>
-              </p>
-              
-              <p className="text-foreground">
-                СПАСИБО, ЧТО ДОВЕРЯЕТЕ МНЕ САМОЕ ЦЕННОЕ — ВАШЕ ВРЕМЯ, ВАШИ ОЖИДАНИЯ И ВОЗМОЖНОСТЬ <span className="text-primary font-semibold">СОЗДАВАТЬ ДЛЯ ВАС ИДЕАЛЬНУЮ ЭСТЕТИКУ.</span>
-              </p>
-              
-              <p className="text-foreground">
-                КАЖДЫЙ ВАШ ОТЗЫВ СОГРЕВАЕТ СЕРДЦЕ И <span className="text-primary font-semibold">ВДОХНОВЛЯЕТ НА НОВЫЕ СВЕРШЕНИЯ.</span>
-              </p>
+            </div>
+
+            <div className="rounded-[32px] border border-primary/30 bg-card/80 p-8 shadow-2xl backdrop-blur-md max-w-xl">
+              <div className="divide-y divide-primary/15">
+                {highlightPoints.map((item) => (
+                  <div key={item.title} className="py-6 first:pt-0 last:pb-0">
+                    <h3 className="text-xs font-semibold uppercase tracking-[0.35em] text-primary/80">
+                      {item.title}
+                    </h3>
+                    <p className="mt-3 text-base leading-relaxed text-foreground/90">
+                      {item.description}
+                    </p>
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
 
           {/* Right side - Reviews columns */}
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            {/* First column - moving up */}
-            <div className="space-y-4 animate-slide-up">
-              {reviews.slice(0, 3).map((review, index) => (
-                <div key={index} className="testimonial-card">
-                  <h4 className="font-bold text-lg mb-3">{review.name}</h4>
-                  <p className="text-sm leading-relaxed">{review.text}</p>
-                </div>
-              ))}
-            </div>
+          <div
+            ref={columnsRef}
+            className="review-columns grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 xl:gap-8 self-end"
+          >
+            {reviewColumns.map((column, columnIndex) => {
+              const direction = columnDirections[columnIndex] ?? 'up';
+              const duration = columnDurations[columnIndex] ?? '28s';
+              const repeatedColumn = [...column, ...column];
 
-            {/* Second column - moving down */}
-            <div className="space-y-4 animate-slide-down">
-              {reviews.slice(3, 6).map((review, index) => (
-                <div key={index + 3} className="testimonial-card">
-                  <h4 className="font-bold text-lg mb-3">{review.name}</h4>
-                  <p className="text-sm leading-relaxed">{review.text}</p>
+              return (
+                <div
+                  key={`column-${columnIndex}`}
+                  className="review-column h-[520px] sm:h-[560px] lg:h-[620px] xl:h-[680px]"
+                >
+                  <div
+                    className={`flex flex-col gap-6 review-marquee ${direction === 'down' ? 'reverse' : ''}`}
+                    style={{ animationDuration: duration }}
+                  >
+                    {repeatedColumn.map((review, reviewIndex) => {
+                      const isDuplicate = reviewIndex >= column.length;
+
+                      return (
+                        <div
+                          key={`${review.code}-${reviewIndex}`}
+                          className="testimonial-card"
+                          aria-hidden={isDuplicate}
+                        >
+                          <div className="flex items-center justify-between text-[10px] font-semibold uppercase tracking-[0.35em] text-primary-foreground/70">
+                            <span>{review.code}</span>
+                            <span>{review.name}</span>
+                          </div>
+                          <p className="mt-5 text-sm leading-relaxed">
+                            {review.text}
+                          </p>
+                        </div>
+                      );
+                    })}
+                  </div>
                 </div>
-              ))}
-            </div>
+              );
+            })}
           </div>
         </div>
       </div>

--- a/src/components/ServicesSection.tsx
+++ b/src/components/ServicesSection.tsx
@@ -3,16 +3,108 @@ import nails1 from '@/assets/nails-1.jpg';
 
 const ServicesSection = () => {
   const services = [
-    { name: 'НАЗВАНИЕ УСЛУГИ', price: '2000 Р.', image: nails1 },
-    { name: 'НАЗВАНИЕ УСЛУГИ', price: '2000 Р.', image: nails1 },
-    { name: 'НАЗВАНИЕ УСЛУГИ', price: '2000 Р.', image: nails1 },
-    { name: 'НАЗВАНИЕ УСЛУГИ', price: '2000 Р.', image: nails1 },
-    { name: 'ОБУЧЕНИЕ 1', price: '30 000 Р.', image: nails1 },
-    { name: 'НАЗВАНИЕ УСЛУГИ', price: '2000 Р.', image: nails1 },
-    { name: 'НАЗВАНИЕ УСЛУГИ', price: '2000 Р.', image: nails1 },
-    { name: 'НАЗВАНИЕ УСЛУГИ', price: '2000 Р.', image: nails1 },
-    { name: 'НАЗВАНИЕ УСЛУГИ', price: '2000 Р.', image: nails1 },
-    { name: 'ОБУЧЕНИЕ 2', price: '40 000 Р.', image: nails1 },
+    {
+      category: 'Снятие',
+      name: 'Снятие нарощенных ногтей',
+      price: '500 ₽',
+      image: nails1,
+    },
+    {
+      category: 'Маникюр',
+      name: 'Маникюр комбинированный',
+      price: '800 ₽',
+      image: nails1,
+    },
+    {
+      category: 'Маникюр',
+      name: 'Авторский маникюр',
+      price: '1 500 ₽',
+      image: nails1,
+    },
+    {
+      category: 'Маникюр',
+      name: 'Японский маникюр',
+      price: '1 000 ₽',
+      image: nails1,
+    },
+    {
+      category: 'Маникюр',
+      name: 'Японский маникюр мужской',
+      price: '1 100 ₽',
+      image: nails1,
+    },
+    {
+      category: 'Покрытие',
+      name: 'Маникюр с покрытием',
+      price: '1 500 ₽',
+      image: nails1,
+    },
+    {
+      category: 'Покрытие',
+      name: 'Маникюр с покрытием френч',
+      price: '1 700 ₽',
+      image: nails1,
+    },
+    {
+      category: 'Коррекция',
+      name: 'Коррекция гелем 1-3 длина',
+      price: '2 000 ₽',
+      image: nails1,
+    },
+    {
+      category: 'Коррекция',
+      name: 'Коррекция гелем 4-5 длина',
+      price: '2 300 ₽',
+      image: nails1,
+    },
+    {
+      category: 'Коррекция',
+      name: 'Коррекция гелем 5-7 длина',
+      price: '3 000 ₽',
+      image: nails1,
+    },
+    {
+      category: 'Наращивание',
+      name: 'Наращивание гелем 1-3 длина',
+      price: '2 300 ₽',
+      image: nails1,
+    },
+    {
+      category: 'Наращивание',
+      name: 'Наращивание гелем 4-5 длина',
+      price: '2 700 ₽',
+      image: nails1,
+    },
+    {
+      category: 'Наращивание',
+      name: 'Наращивание гелем 5-7 длина',
+      price: '3 000 ₽',
+      image: nails1,
+    },
+    {
+      category: 'Педикюр',
+      name: 'Педикюр обработка пальцев ног',
+      price: '1 500 ₽',
+      image: nails1,
+    },
+    {
+      category: 'Педикюр',
+      name: 'Педикюр обработка пальцев ног с покрытием',
+      price: '1 800 ₽',
+      image: nails1,
+    },
+  ];
+
+  const frameGradients = [
+    'from-brand-pink/80 via-brand-pink/20 to-transparent',
+    'from-rose-500/80 via-brand-pink/20 to-transparent',
+    'from-purple-500/80 via-rose-500/20 to-transparent',
+  ];
+
+  const panelGradients = [
+    'from-brand-pink/15 via-transparent to-transparent',
+    'from-rose-500/15 via-transparent to-transparent',
+    'from-purple-500/15 via-transparent to-transparent',
   ];
 
   return (
@@ -35,30 +127,48 @@ const ServicesSection = () => {
         </div>
 
         {/* Services Grid */}
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-6">
-          {services.map((service, index) => (
-            <div key={index} className="service-card group">
-              <div className="aspect-square overflow-hidden rounded-t-3xl">
-                <img 
-                  src={service.image} 
-                  alt={service.name}
-                  className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-300"
-                />
+        <div className="grid grid-cols-1 gap-8 md:grid-cols-3 xl:grid-cols-5">
+          {services.map((service, index) => {
+            const rowIndex = Math.floor(index / 5);
+            const frameGradient = frameGradients[rowIndex % frameGradients.length];
+            const panelGradient = panelGradients[rowIndex % panelGradients.length];
+
+            return (
+              <div
+                key={service.name}
+                className={`rounded-[34px] bg-gradient-to-br ${frameGradient} p-[1.5px]`}
+              >
+                <div className="service-card group flex h-full flex-col !border-0 !bg-background/95 !rounded-[30px]">
+                  <div className="aspect-square overflow-hidden rounded-t-[28px]">
+                    <img
+                      src={service.image}
+                      alt={service.name}
+                      className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-110"
+                    />
+                  </div>
+
+                  <div
+                    className={`flex flex-1 flex-col justify-between gap-6 rounded-b-[28px] bg-gradient-to-br ${panelGradient} p-6 text-center`}
+                  >
+                    <div className="space-y-3">
+                      {service.category && (
+                        <span className="inline-flex items-center justify-center rounded-full bg-primary/15 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-primary">
+                          {service.category}
+                        </span>
+                      )}
+                      <h3 className="font-semibold text-sm leading-tight text-foreground">
+                        {service.name}
+                      </h3>
+                      <p className="text-lg font-bold text-primary">{service.price}</p>
+                    </div>
+                    <Button className="btn-hero w-full py-2 text-sm">
+                      ЗАПИСАТЬСЯ
+                    </Button>
+                  </div>
+                </div>
               </div>
-              
-              <div className="p-6 text-center space-y-4">
-                <h3 className="font-semibold text-foreground text-sm">
-                  {service.name}
-                </h3>
-                <p className="text-primary font-bold text-lg">
-                  {service.price}
-                </p>
-                <Button className="w-full btn-hero text-sm py-2">
-                  ЗАПИСАТЬСЯ
-                </Button>
-              </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       </div>
     </section>

--- a/src/index.css
+++ b/src/index.css
@@ -142,10 +142,45 @@
   
   /* Testimonial card styles */
   .testimonial-card {
-    @apply bg-primary text-primary-foreground rounded-2xl p-6 mb-4;
+    @apply relative overflow-hidden rounded-[28px] border border-primary/40 bg-primary text-primary-foreground p-6;
     box-shadow: var(--shadow-pink);
   }
-  
+
+  .review-columns {
+    --review-mask-top: 160px;
+  }
+
+  .review-column {
+    @apply relative overflow-hidden;
+  }
+
+  .review-column::before,
+  .review-column::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    height: 72px;
+    pointer-events: none;
+    z-index: 10;
+  }
+
+  .review-column::before {
+    top: 0;
+    height: clamp(96px, var(--review-mask-top, 160px), 360px);
+    background: linear-gradient(
+      to bottom,
+      hsl(var(--background)) 0%,
+      hsl(var(--background)) 60%,
+      transparent 100%
+    );
+  }
+
+  .review-column::after {
+    bottom: 0;
+    background: linear-gradient(to top, hsl(var(--background)) 0%, transparent 100%);
+  }
+
   /* Certificate card styles */
   .certificate-card {
     @apply bg-card border border-primary/30 rounded-2xl overflow-hidden;
@@ -193,5 +228,31 @@
   
   .animate-slide-down {
     animation: slideDown 1s ease-out;
+  }
+
+  /* Reviews marquee animation */
+  .review-marquee {
+    animation: review-marquee 28s linear infinite;
+    will-change: transform;
+  }
+
+  .review-marquee.reverse {
+    animation-direction: reverse;
+  }
+
+  @keyframes review-marquee {
+    0% {
+      transform: translateY(0%);
+    }
+    100% {
+      transform: translateY(-50%);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .review-marquee {
+      animation: none !important;
+      transform: none !important;
+    }
   }
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -7,16 +7,26 @@ import ReviewsSection from '@/components/ReviewsSection';
 import CertificatesSection from '@/components/CertificatesSection';
 import Footer from '@/components/Footer';
 
+const SectionDivider = () => (
+  <div className="h-[3px] w-full bg-[#FF62B1]" aria-hidden="true" />
+);
+
 const Index = () => {
   return (
     <div className="min-h-screen bg-background">
       <Header />
       <HeroSection />
+      <SectionDivider />
       <AboutSection />
+      <SectionDivider />
       <ServicesSection />
+      <SectionDivider />
       <PortfolioSection />
+      <SectionDivider />
       <ReviewsSection />
+      <SectionDivider />
       <CertificatesSection />
+      <SectionDivider />
       <Footer />
     </div>
   );


### PR DESCRIPTION
## Summary
- expand the certificates data set and grid so eight certificates render at once in a responsive layout
- reposition the heading and supporting copy to the right with a refined accent label and spacing to mirror the reference

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1bb0cea74832190c38865facd93fa