### PR TITLE
Redesign certificates section layout

### DIFF
--- a/src/components/CertificatesSection.tsx
+++ b/src/components/CertificatesSection.tsx
@@ -1,56 +1,59 @@
 import certificate1 from '@/assets/certificate-1.jpg';
 
-const CertificatesSection = () => {
-  const certificates = [
-    { name: 'НАЗВАНИЕ 1', image: certificate1 },
-    { name: 'НАЗВАНИЕ 2', image: certificate1 },
-    { name: 'НАЗВАНИЕ 3', image: certificate1 },
-    { name: 'НАЗВАНИЕ 4', image: certificate1 },
-    { name: 'НАЗВАНИЕ 5', image: certificate1 },
-    { name: 'НАЗВАНИЕ 6', image: certificate1 },
-    { name: 'НАЗВАНИЕ 7', image: certificate1 },
-    { name: 'НАЗВАНИЕ 8', image: certificate1 },
-  ];
+const certificates = [
+  { name: 'НАЗВАНИЕ 1', image: certificate1 },
+  { name: 'НАЗВАНИЕ 2', image: certificate1 },
+  { name: 'НАЗВАНИЕ 3', image: certificate1 },
+  { name: 'НАЗВАНИЕ 4', image: certificate1 },
+  { name: 'НАЗВАНИЕ 5', image: certificate1 },
+  { name: 'НАЗВАНИЕ 6', image: certificate1 },
+  { name: 'НАЗВАНИЕ 7', image: certificate1 },
+  { name: 'НАЗВАНИЕ 8', image: certificate1 },
+];
 
+const CertificatesSection = () => {
   return (
     <section id="certificates" className="py-24 bg-background">
       <div className="container mx-auto px-4">
-        <div className="flex flex-col lg:flex-row lg:items-start gap-12 xl:gap-20">
+        <div className="flex flex-col-reverse gap-12 lg:grid lg:grid-cols-[minmax(0,1fr)_320px] xl:grid-cols-[minmax(0,1fr)_360px] lg:items-center xl:gap-20">
           {/* Certificates grid */}
-          <div className="flex-1 order-2 lg:order-1">
-            <div className="grid grid-cols-2 sm:grid-cols-3 xl:grid-cols-4 gap-6 xl:gap-8">
-              {certificates.map((cert, index) => (
-                <div key={index} className="certificate-card group">
-                  <div className="aspect-[3/4] overflow-hidden rounded-t-2xl">
-                    <img
-                      src={cert.image}
-                      alt={cert.name}
-                      className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-300"
-                    />
-                  </div>
-                  <div className="p-4 text-center">
-                    <h3 className="font-semibold text-foreground text-sm tracking-wide uppercase">
-                      {cert.name}
-                    </h3>
-                  </div>
+          <div className="grid grid-cols-2 gap-6 sm:grid-cols-3 lg:grid-cols-4 xl:gap-8">
+            {certificates.map((cert) => (
+              <article
+                key={cert.name}
+                className="group relative flex flex-col overflow-hidden rounded-[28px] border border-white/10 bg-gradient-to-b from-background/80 via-background/60 to-background/80 shadow-[0_20px_60px_rgba(15,15,15,0.45)] transition-all duration-500 hover:-translate-y-2 hover:shadow-[0_32px_80px_rgba(15,15,15,0.55)]"
+              >
+                <div className="relative aspect-[3/4] overflow-hidden">
+                  <img
+                    src={cert.image}
+                    alt={cert.name}
+                    className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-110"
+                  />
+                  <span className="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-primary/80 via-primary to-primary/80 opacity-0 transition-opacity duration-500 group-hover:opacity-100" />
                 </div>
-              ))}
-            </div>
+                <div className="flex flex-col items-center gap-2 px-6 py-5 text-center">
+                  <span className="text-[10px] uppercase tracking-[0.65em] text-muted-foreground">сертификат</span>
+                  <h3 className="font-semibold text-sm uppercase tracking-[0.3em] text-foreground">{cert.name}</h3>
+                </div>
+              </article>
+            ))}
           </div>
 
           {/* Right side - Header text */}
-          <div className="order-1 lg:order-2 lg:max-w-sm xl:max-w-md lg:pt-4">
-            <div className="flex flex-col items-center lg:items-end gap-6 text-center lg:text-right">
-              <div className="space-y-3">
-                <span className="inline-block text-xs tracking-[0.6em] uppercase text-muted-foreground">достижения</span>
-                <h2 className="font-heading text-4xl lg:text-5xl xl:text-6xl font-bold gradient-text">
-                  СЕРТИФИКАТЫ
-                </h2>
-              </div>
-              <p className="text-lg leading-relaxed text-foreground">
-                <span className="text-primary font-semibold">Я ГОРЖУСЬ КАЖДЫМ ИЗ ЭТИХ СЕРТИФИКАТОВ</span> — ОНИ НАПОМИНАЮТ МНЕ О ПУТИ, КОТОРЫЙ Я ПРОШЛА, ЧТОБЫ <span className="text-primary font-semibold">ДАВАТЬ ВАМ ТОЛЬКО ЛУЧШЕЕ.</span>
-              </p>
+          <div className="flex flex-col items-center gap-8 text-center lg:items-end lg:text-right">
+            <div className="space-y-4">
+              <span className="inline-flex items-center gap-2 rounded-full border border-primary/40 px-4 py-1 text-[11px] font-medium uppercase tracking-[0.5em] text-muted-foreground/90">
+                <span className="h-2 w-2 rounded-full bg-primary" />достижения
+              </span>
+              <h2 className="font-heading text-4xl font-bold uppercase tracking-[0.25em] text-foreground lg:text-5xl xl:text-6xl">
+                СЕРТИФИКАТЫ
+              </h2>
             </div>
+            <p className="max-w-sm text-sm font-medium leading-relaxed tracking-[0.25em] text-muted-foreground uppercase lg:max-w-none lg:text-base">
+              <span className="text-foreground">Я ГОРЖУСЬ КАЖДЫМ ИЗ ЭТИХ СЕРТИФИКАТОВ</span>
+              {' — ОНИ НАПОМИНАЮТ МНЕ О ПУТИ, КОТОРЫЙ Я ПРОШЛА, ЧТОБЫ '}
+              <span className="text-primary">ДАВАТЬ ВАМ ТОЛЬКО ЛУЧШЕЕ.</span>
+            </p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- redesign the certificates section layout to support eight cards in two balanced rows
- restyle each certificate card with modern hover states and uppercase labelling
- reposition the section header copy on the right with uppercase achievements badge and improved typography

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68d2090364f48321a1098f49645159ef